### PR TITLE
Force utf-8 encoding in API.__request()

### DIFF
--- a/woocommerce/api.py
+++ b/woocommerce/api.py
@@ -66,7 +66,7 @@ class API(object):
             url = self.__get_oauth_url(url, method)
 
         if data is not None:
-            data = jsonencode(data, ensure_ascii=False)
+            data = jsonencode(data, ensure_ascii=False).encode('utf-8')
 
         return request(
             method=method,


### PR DESCRIPTION
Just before sending data , encode it (if it's not `None`) in UTF-8 to avoid `UnicodeDecodeError` with the requests lib.