### PR TITLE
Add option to auth with https with query param

### DIFF
--- a/tests.py
+++ b/tests.py
@@ -134,5 +134,5 @@ class WooCommerceTestCase(unittest.TestCase):
 
         with HTTMock(woo_test_mock):
             url = api.get("products").url
-        self.assertIn('consumer_key={}'.format(self.consumer_key), url)
-        self.assertIn('consumer_secret={}'.format(self.consumer_secret), url)
+        self.assertTrue('consumer_key={0}'.format(self.consumer_key) in url)
+        self.assertTrue('consumer_secret={0}'.format(self.consumer_secret) in url)

--- a/tests.py
+++ b/tests.py
@@ -116,3 +116,23 @@ class WooCommerceTestCase(unittest.TestCase):
             # call requests
             status = self.api.delete("products").status_code
         self.assertEqual(status, 200)
+
+    def test_get_with_https_and_query_params(self):
+        api = woocommerce.API(
+            url="https://woo.test",
+            consumer_key=self.consumer_key,
+            consumer_secret=self.consumer_secret,
+            auth_query_string=True,
+        )
+        self.assertEqual(api.auth_query_string, True)
+
+        @all_requests
+        def woo_test_mock(*args, **kwargs):
+            """ URL Mock """
+            return {'status_code': 200,
+                    'content': 'OK'}
+
+        with HTTMock(woo_test_mock):
+            url = api.get("products").url
+        self.assertIn('consumer_key={}'.format(self.consumer_key), url)
+        self.assertIn('consumer_secret={}'.format(self.consumer_secret), url)

--- a/woocommerce/api.py
+++ b/woocommerce/api.py
@@ -64,11 +64,11 @@ class API(object):
         }
 
         if self.is_ssl is True:
+            auth = (self.consumer_key, self.consumer_secret)
+
             if self.auth_query_string is True:
                 params = {'consumer_key': self.consumer_key,
                           'consumer_secret': self.consumer_secret}
-            else:
-                auth = (self.consumer_key, self.consumer_secret)
         else:
             url = self.__get_oauth_url(url, method)
 

--- a/woocommerce/api.py
+++ b/woocommerce/api.py
@@ -25,6 +25,7 @@ class API(object):
         self.is_ssl = self.__is_ssl()
         self.timeout = kwargs.get("timeout", 5)
         self.verify_ssl = kwargs.get("verify_ssl", True)
+        self.auth_query_string = kwargs.get("auth_query_string", False)
 
     def __is_ssl(self):
         """ Check if url use HTTPS """
@@ -55,6 +56,7 @@ class API(object):
         """ Do requests """
         url = self.__get_url(endpoint)
         auth = None
+        params = None
         headers = {
             "user-agent": "WooCommerce API Client-Node.js/%s" % __version__,
             "content-type": "application/json;charset=utf-8",
@@ -62,7 +64,11 @@ class API(object):
         }
 
         if self.is_ssl is True:
-            auth = (self.consumer_key, self.consumer_secret)
+            if self.auth_query_string is True:
+                params = {'consumer_key': self.consumer_key,
+                          'consumer_secret': self.consumer_secret}
+            else:
+                auth = (self.consumer_key, self.consumer_secret)
         else:
             url = self.__get_oauth_url(url, method)
 
@@ -76,7 +82,8 @@ class API(object):
             auth=auth,
             data=data,
             timeout=self.timeout,
-            headers=headers
+            headers=headers,
+            params=params,
         )
 
     def get(self, endpoint):


### PR DESCRIPTION
Some https stores lost auth header them need to send it with query params

http://woothemes.github.io/woocommerce-rest-api-docs/#authentication
