### PR TITLE
Updated SSL auth

### DIFF
--- a/woocommerce/api.py
+++ b/woocommerce/api.py
@@ -62,7 +62,11 @@ class API(object):
         }
 
         if self.is_ssl is True:
-            auth = (self.consumer_key, self.consumer_secret)
+            if "?" not in url:
+                url += "?"
+            else:
+                url += "&"
+            url = "%sconsumer_key=%s&consumer_secret=%s" % (url, self.consumer_key, self.consumer_secret)
         else:
             url = self.__get_oauth_url(url, method)
 


### PR DESCRIPTION
According to the function 'perform_ssl_authentication()' inside of woocommerce/includes/api/class-wc-api-authentication.php, the consumer_key and consumer_secret must be passed in the URL as GET parameters when authenticating over SSL.

Without the change I'm proposing, I was unable to get this module to work with my SSL-enabled server. The error message was consistently "Consumer Secret is invalid".

This change is working smoothly for me in a production environment, however if this change is not needed and I'm doing something wrong I would appreciate the feedback.