### PR TITLE
add 'Connection':'close' to the request

### DIFF
--- a/woocommerce/api.py
+++ b/woocommerce/api.py
@@ -70,7 +70,8 @@ class API(object):
         auth = None
         headers = {
             "user-agent": f"{self.user_agent}",
-            "accept": "application/json"
+            "accept": "application/json",
+            "Connection":"close"
         }
 
         if self.is_ssl is True and self.query_string_auth is False:


### PR DESCRIPTION
Hi Woocommerce team,

I use your api for updating prices and stock on a website , but when multiple requests are made in row there is a spike in ram on the server and the server crashes if there is other high loads on the site at the same time.
this is a try to solve this problem , by closing the connection after the request is done

Thanks,
ahmed hanafi