### PR TITLE
Don't break URL just because HTTP is used without parameters.

### DIFF
--- a/woocommerce/api.py
+++ b/woocommerce/api.py
@@ -82,7 +82,8 @@ class API(object):
             })
         else:
             encoded_params = urlencode(params)
-            url = f"{url}?{encoded_params}"
+            if len(encoded_params) != 0:
+                url = f"{url}?{encoded_params}"
             url = self.__get_oauth_url(url, method, **kwargs)
 
         if data is not None:


### PR DESCRIPTION
While using http connection without extra parameters url constructor add undesired "?" 
example:
```
wcapi.get("/products?sku=test")
```
with http connection will become:
```
http://example.domain/wp-json/wc/v3/products?sku=test%3F&oauth_consumer_key=ck_xxx&oauth_timestamp=1717745432&oauth_nonce=12afaxxx&oauth_signature_method=HMAC-SHA256&oauth_signature=kxxxx
```

after test there is added ? then its coded with parameters (or the absense of them) as %3F which breaks api.