### PR TITLE
Pin GitHub Actions to full commit SHAs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,12 +12,12 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
     steps:
     - name: Checkout code
-      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@e9aba2c848f5ebd159c070c61ea2c4e2b122355e # v2
+      uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,9 +15,9 @@ jobs:
         python-version: [3.6, 3.7, 3.8, 3.9]
     steps:
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@e9aba2c848f5ebd159c070c61ea2c4e2b122355e # v2
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,9 +10,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@e9aba2c848f5ebd159c070c61ea2c4e2b122355e # v2
       with:
         python-version: '3.9'
     - name: Install dependencies

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,9 +10,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout code
-      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
     - name: Set up Python
-      uses: actions/setup-python@e9aba2c848f5ebd159c070c61ea2c4e2b122355e # v2
+      uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
       with:
         python-version: '3.9'
     - name: Install dependencies

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,4 +1,4 @@
 -r requirements.txt
 httmock==1.4.0
-pytest==6.2.2
-flake8==3.8.4
+pytest==8.3.5
+flake8==7.1.2


### PR DESCRIPTION
## Changes proposed in this pull request

- Pin every third-party GitHub Action used by this repository to a full 40-character commit SHA. The prior human-readable tag is retained in an inline comment so future updates remain understandable.
- Update `actions/checkout` from `v2` to `v4` and `actions/setup-python` from `v2` to `v5`, while keeping both actions pinned to the exact commits for those major-version tags.
- Replace the unsupported Python 3.6 and 3.7 CI jobs with a quoted Python 3.8–3.12 matrix. The previous Python 3.7 job failed during `setup-python` because that version was unavailable on the current GitHub-hosted runner, before dependencies or tests could run.
- Update the pinned CI-only `pytest` and `flake8` versions to releases that support Python 3.8–3.12. The old `flake8==3.8.4` crashed with current `importlib-metadata` after the runner setup problem was removed.

The WooCommerce organization intends to enforce full-length commit SHA pinning for Actions at the organization level. Landing this change first avoids disrupting this repository when enforcement is enabled. Immutable action revisions reduce the risk that a moved or compromised upstream tag can be used for a CI/CD supply-chain exploit.

## How to test

- Confirm each external `uses:` reference ends in a 40-character commit SHA.
- Confirm each pinned action retains its major version in the inline comment (`# v4` or `# v5`).
- Confirm the CI matrix runs Python 3.8, 3.9, 3.10, 3.11, and 3.12.
- Parse both changed workflow files as YAML and run `git diff --check`.
- Install `requirements-test.txt`, run both workflow flake8 commands, and run the pytest suite.
- Confirm the GitHub Actions matrix reaches dependency installation and tests on the current hosted runners.

## Changelog

No changelog entry is needed because this only hardens and repairs CI configuration and does not change the shipped package.
